### PR TITLE
feat: composite primary key

### DIFF
--- a/debil-derive/src/lib.rs
+++ b/debil-derive/src/lib.rs
@@ -219,7 +219,6 @@ pub fn derive_record(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
             let size = option_to_quote(size_opt);
             let unique = option_to_quote(attr_map.get("unique").map(|v| v.clone().as_bool().unwrap()));
             let not_null = option_to_quote(attr_map.get("not_null").map(|v| v.clone().as_bool().unwrap()));
-            let primary_key = option_to_quote(attr_map.get("primary_key").map(|v| v.clone().as_bool().unwrap()));
             let size_unopt = size_opt.unwrap_or(0);
 
             quote! {
@@ -227,7 +226,6 @@ pub fn derive_record(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
                     size: #size,
                     unique: #unique,
                     not_null: #not_null,
-                    primary_key: #primary_key,
                 }));
             }
         })

--- a/debil-derive/src/lib.rs
+++ b/debil-derive/src/lib.rs
@@ -43,7 +43,7 @@ impl AttrInput {
                     table.sql_type = quote! { #sql_type };
                 }
                 "primary_key_columns" => {
-                    table.primary_key_columns = attr.value.as_str().unwrap().split(",").map(|s| s.to_string()).collect();
+                    table.primary_key_columns = attr.value.as_str().unwrap().split(",").map(|s| s.trim().to_string()).collect();
                 },
                 d => panic!("unsupported attribute: {}", d),
             }

--- a/debil-derive/src/lib.rs
+++ b/debil-derive/src/lib.rs
@@ -7,7 +7,7 @@ use syn::{parse_macro_input, DeriveInput, Result};
 
 struct TableAttr {
     table_name: String,
-    primary_key_columns: Vec<String>,
+    primary_key: Vec<String>,
     sql_type: proc_macro2::TokenStream,
 }
 
@@ -30,7 +30,7 @@ impl AttrInput {
     fn to_table_attr(self, table_name: String) -> TableAttr {
         let mut table = TableAttr {
             table_name: table_name,
-            primary_key_columns: vec![],
+            primary_key: vec![],
             sql_type: quote! { Vec<u8> },
         };
 
@@ -42,8 +42,8 @@ impl AttrInput {
                         syn::parse_str::<syn::Type>(&attr.value.as_str().unwrap()).unwrap();
                     table.sql_type = quote! { #sql_type };
                 }
-                "primary_key_columns" => {
-                    table.primary_key_columns = attr
+                "primary_key" => {
+                    table.primary_key = attr
                         .value
                         .as_str()
                         .unwrap()
@@ -196,7 +196,7 @@ pub fn derive_record(input: proc_macro::TokenStream) -> proc_macro::TokenStream 
 
     let field_struct = get_fields_from_datastruct(input.data);
 
-    let primary_key_columns = table_attr.primary_key_columns;
+    let primary_key_columns = table_attr.primary_key;
     if primary_key_columns.len() == 0 {
         panic!("At least one primary key must be specified")
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,13 +54,9 @@ pub trait SQLTable: SQLMapper {
 
     fn primary_key_columns(_: std::marker::PhantomData<Self>) -> Vec<String>;
 
-    fn add_primary_key_query(ty: std::marker::PhantomData<Self>) -> String {
+    fn constraint_primary_key_query(ty: std::marker::PhantomData<Self>) -> String {
         let columns = SQLTable::primary_key_columns(ty);
-        format!(
-            "ALTER TABLE {} ADD PRIMARY KEY({})",
-            SQLTable::table_name(ty),
-            columns.join(",")
-        )
+        format!("CONSTRAINT primary_key PRIMARY KEY({})", columns.join(","))
     }
 
     fn map_to_sql(self) -> Vec<(String, Self::ValueType)>;
@@ -69,14 +65,15 @@ pub trait SQLTable: SQLMapper {
         let schema = SQLTable::schema_of(ty);
 
         format!(
-            "CREATE TABLE IF NOT EXISTS {} ({})",
+            "CREATE TABLE IF NOT EXISTS {} ({}, {})",
             SQLTable::table_name(ty),
             schema
                 .into_iter()
                 .map(|(name, typ, attr)| create_column_query(name, typ, attr))
                 .collect::<Vec<_>>()
                 .as_slice()
-                .join(", ")
+                .join(", "),
+            SQLTable::constraint_primary_key_query(ty),
         )
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,17 @@ pub trait SQLTable: SQLMapper {
     fn table_name(_: std::marker::PhantomData<Self>) -> String;
     fn schema_of(_: std::marker::PhantomData<Self>) -> Vec<(String, String, FieldAttribute)>;
 
+    fn primary_key_columns(_: std::marker::PhantomData<Self>) -> Vec<String>;
+
+    fn add_primary_key_query(ty: std::marker::PhantomData<Self>) -> String {
+        let columns = SQLTable::primary_key_columns(ty);
+        format!(
+            "ALTER TABLE {} ADD PRIMARY KEY({})",
+            SQLTable::table_name(ty),
+            columns.join(",")
+        )
+    }
+
     fn map_to_sql(self) -> Vec<(String, Self::ValueType)>;
 
     fn create_table_query(ty: std::marker::PhantomData<Self>) -> String {
@@ -105,6 +116,10 @@ pub fn table_name<T: SQLTable>() -> String {
 
 pub fn schema_of<T: SQLTable>() -> Vec<(String, String, FieldAttribute)> {
     SQLTable::schema_of(std::marker::PhantomData::<T>)
+}
+
+pub fn primary_key_columns<T: SQLTable>() -> Vec<String> {
+    SQLTable::primary_key_columns(std::marker::PhantomData::<T>)
 }
 
 pub fn map_from_sql<T: SQLMapper>(h: std::collections::HashMap<String, T::ValueType>) -> T {

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,7 +3,6 @@ pub struct FieldAttribute {
     pub size: Option<i32>,
     pub unique: Option<bool>,
     pub not_null: Option<bool>,
-    pub primary_key: Option<bool>,
 }
 
 impl Default for FieldAttribute {
@@ -12,7 +11,6 @@ impl Default for FieldAttribute {
             size: None,
             unique: None,
             not_null: None,
-            primary_key: None,
         }
     }
 }
@@ -25,11 +23,6 @@ pub fn create_column_query(
     [
         &[column_name.as_str(), column_type.as_str()],
         vec![
-            if attr.primary_key.unwrap_or(false) {
-                Some("PRIMARY KEY")
-            } else {
-                None
-            },
             if attr.unique.unwrap_or(false) {
                 Some("UNIQUE")
             } else {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use debil::*;
 
 #[derive(Table, PartialEq, Debug, Clone)]
-#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "pk")]
+#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "")]
 struct Ex1 {
     #[sql(size = 50, unique = true, not_null = true)]
     field1: String,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -79,12 +79,12 @@ fn it_derives_sql_table() {
 
     assert_eq!(
         SQLTable::create_table_query(std::marker::PhantomData::<Ex1>),
-        "CREATE TABLE IF NOT EXISTS ex_1 (field1 varchar(50) UNIQUE NOT NULL, aaaa int, pk int)"
+        "CREATE TABLE IF NOT EXISTS ex_1 (field1 varchar(50) UNIQUE NOT NULL, aaaa int, pk int, CONSTRAINT primary_key PRIMARY KEY(pk))"
     );
 
     assert_eq!(
-        SQLTable::add_primary_key_query(std::marker::PhantomData::<Ex1>),
-        "ALTER TABLE ex_1 ADD PRIMARY KEY(pk)"
+        SQLTable::constraint_primary_key_query(std::marker::PhantomData::<Ex1>),
+        "CONSTRAINT primary_key PRIMARY KEY(pk)"
     )
 }
 
@@ -112,7 +112,7 @@ fn composite_primary_key() {
     };
 
     assert_eq!(
-        SQLTable::add_primary_key_query(std::marker::PhantomData::<Ex2>),
-        "ALTER TABLE ex_1 ADD PRIMARY KEY(pk,pk2)"
+        SQLTable::constraint_primary_key_query(std::marker::PhantomData::<Ex2>),
+        "CONSTRAINT primary_key PRIMARY KEY(pk,pk2)"
     )
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use debil::*;
 
 #[derive(Table, PartialEq, Debug, Clone)]
-#[sql(table_name = "ex_1", sql_type = "Vec<u8>")]
+#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "pk")]
 struct Ex1 {
     #[sql(size = 50, unique = true, not_null = true)]
     field1: String,
@@ -19,6 +19,7 @@ fn it_derives_sql_table() {
     };
 
     assert_eq!(table_name::<Ex1>(), "ex_1");
+    assert_eq!(primary_key_columns::<Ex1>(), vec!["pk"]);
     assert_eq!(
         schema_of::<Ex1>(),
         vec![

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use debil::*;
 
 #[derive(Table, PartialEq, Debug, Clone)]
-#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "pk")]
+#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key = "pk")]
 struct Ex1 {
     #[sql(size = 50, unique = true, not_null = true)]
     field1: String,
@@ -91,11 +91,7 @@ fn it_derives_sql_table() {
 #[test]
 fn composite_primary_key() {
     #[derive(Table, PartialEq, Debug, Clone)]
-    #[sql(
-        table_name = "ex_1",
-        sql_type = "Vec<u8>",
-        primary_key_columns = "pk,pk2"
-    )]
+    #[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key = "pk,pk2")]
     struct Ex2 {
         #[sql(size = 50, unique = true, not_null = true)]
         field1: String,
@@ -117,11 +113,7 @@ fn composite_primary_key() {
     );
 
     #[derive(Table, PartialEq, Debug, Clone)]
-    #[sql(
-        table_name = "ex_1",
-        sql_type = "Vec<u8>",
-        primary_key_columns = "pk ,pk2"
-    )]
+    #[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key = "pk ,pk2")]
     struct Ex3 {
         #[sql(size = 50, unique = true, not_null = true)]
         field1: String,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,7 +1,7 @@
 use debil::*;
 
 #[derive(Table, PartialEq, Debug, Clone)]
-#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "")]
+#[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "pk")]
 struct Ex1 {
     #[sql(size = 50, unique = true, not_null = true)]
     field1: String,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -91,7 +91,11 @@ fn it_derives_sql_table() {
 #[test]
 fn composite_primary_key() {
     #[derive(Table, PartialEq, Debug, Clone)]
-    #[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "pk,pk2")]
+    #[sql(
+        table_name = "ex_1",
+        sql_type = "Vec<u8>",
+        primary_key_columns = "pk,pk2"
+    )]
     struct Ex2 {
         #[sql(size = 50, unique = true, not_null = true)]
         field1: String,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -81,4 +81,34 @@ fn it_derives_sql_table() {
         SQLTable::create_table_query(std::marker::PhantomData::<Ex1>),
         "CREATE TABLE IF NOT EXISTS ex_1 (field1 varchar(50) UNIQUE NOT NULL, aaaa int, pk int)"
     );
+
+    assert_eq!(
+        SQLTable::add_primary_key_query(std::marker::PhantomData::<Ex1>),
+        "ALTER TABLE ex_1 ADD PRIMARY KEY(pk)"
+    )
+}
+
+#[test]
+fn composite_primary_key() {
+    #[derive(Table, PartialEq, Debug, Clone)]
+    #[sql(table_name = "ex_1", sql_type = "Vec<u8>", primary_key_columns = "pk,pk2")]
+    struct Ex2 {
+        #[sql(size = 50, unique = true, not_null = true)]
+        field1: String,
+        aaaa: i32,
+        pk: i32,
+        pk2: i32,
+    }
+
+    let ex2 = Ex2 {
+        field1: "aaa".to_string(),
+        aaaa: 10,
+        pk: 1,
+        pk2: 1,
+    };
+
+    assert_eq!(
+        SQLTable::add_primary_key_query(std::marker::PhantomData::<Ex2>),
+        "ALTER TABLE ex_1 ADD PRIMARY KEY(pk,pk2)"
+    )
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -6,7 +6,6 @@ struct Ex1 {
     #[sql(size = 50, unique = true, not_null = true)]
     field1: String,
     aaaa: i32,
-    #[sql(primary_key = true)]
     pk: i32,
 }
 
@@ -38,7 +37,6 @@ fn it_derives_sql_table() {
                 "pk".to_string(),
                 "int".to_string(),
                 FieldAttribute {
-                    primary_key: Some(true),
                     ..Default::default()
                 }
             ),
@@ -81,6 +79,6 @@ fn it_derives_sql_table() {
 
     assert_eq!(
         SQLTable::create_table_query(std::marker::PhantomData::<Ex1>),
-        "CREATE TABLE IF NOT EXISTS ex_1 (field1 varchar(50) UNIQUE NOT NULL, aaaa int, pk int PRIMARY KEY)"
+        "CREATE TABLE IF NOT EXISTS ex_1 (field1 varchar(50) UNIQUE NOT NULL, aaaa int, pk int)"
     );
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -114,5 +114,20 @@ fn composite_primary_key() {
     assert_eq!(
         SQLTable::constraint_primary_key_query(std::marker::PhantomData::<Ex2>),
         "CONSTRAINT primary_key PRIMARY KEY(pk,pk2)"
-    )
+    );
+
+    #[derive(Table, PartialEq, Debug, Clone)]
+    #[sql(
+        table_name = "ex_1",
+        sql_type = "Vec<u8>",
+        primary_key_columns = "pk ,pk2"
+    )]
+    struct Ex3 {
+        #[sql(size = 50, unique = true, not_null = true)]
+        field1: String,
+        aaaa: i32,
+        pk: i32,
+        pk2: i32,
+    }
+    assert_eq!(primary_key_columns::<Ex3>(), vec!["pk", "pk2"]);
 }


### PR DESCRIPTION
### 実装したこと

- primary keyの指定をカラム単位からテーブル単位に移行
- テーブル作成時にprimary_keyを指定するように
- proc macroでプライマリーキーに含まれるカラム名を指定できるように（複数可、存在しないカラムを指定した場合panicするように）